### PR TITLE
Handle ZoneHelper already being loaded

### DIFF
--- a/ZoneHelper/ZoneHelper.lua
+++ b/ZoneHelper/ZoneHelper.lua
@@ -1,5 +1,6 @@
 local AceEvent = LibStub:GetLibrary("AceEvent-3.0");
 local helper = LibStub:NewLibrary("ZoneHelper-1.0", 1);
+if not helper then return end
 
 local zoneIDToUiMapID = {};
 


### PR DESCRIPTION
Questie is using a copy of this lib now, which is causing problems, when both addons try to define the same library. This check should stop errors being emitted. (I've submitted a similar PR to them)